### PR TITLE
fix: improve OG preview templates for Telegram and social crawlers

### DIFF
--- a/templates/default/link.html
+++ b/templates/default/link.html
@@ -1,17 +1,24 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: http://ogp.me/ns#">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{.Title}}</title>
     <meta name="description" content="{{.Description}}">
+    <meta property="og:type" content="website">
     <meta property="og:title" content="{{.Title}}">
     <meta property="og:description" content="{{.Description}}">
-    <meta property="og:image" content="{{.ImageURL}}">
+    {{if .ImageURL}}<meta property="og:image" content="{{.ImageURL}}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">{{end}}
     <meta property="og:url" content="{{.URL}}">
-    <meta http-equiv="refresh" content="0;url={{.URL}}">
+    <meta name="twitter:card" content="{{if .ImageURL}}summary_large_image{{else}}summary{{end}}">
+    <meta name="twitter:title" content="{{.Title}}">
+    <meta name="twitter:description" content="{{.Description}}">
+    {{if .ImageURL}}<meta name="twitter:image" content="{{.ImageURL}}">{{end}}
 </head>
 <body>
     <p>Redirecting to <a href="{{.URL}}">{{.URL}}</a>.</p>
+    <script>window.location.href = "{{.URL}}";</script>
 </body>
 </html>

--- a/templates/default/preview.html
+++ b/templates/default/preview.html
@@ -1,14 +1,21 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: http://ogp.me/ns#">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{.Title}}</title>
     <meta name="description" content="{{.Description}}">
+    <meta property="og:type" content="website">
     <meta property="og:title" content="{{.Title}}">
     <meta property="og:description" content="{{.Description}}">
-    <meta property="og:image" content="{{.ImageURL}}">
+    {{if .ImageURL}}<meta property="og:image" content="{{.ImageURL}}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">{{end}}
     <meta property="og:url" content="{{.URL}}">
+    <meta name="twitter:card" content="{{if .ImageURL}}summary_large_image{{else}}summary{{end}}">
+    <meta name="twitter:title" content="{{.Title}}">
+    <meta name="twitter:description" content="{{.Description}}">
+    {{if .ImageURL}}<meta name="twitter:image" content="{{.ImageURL}}">{{end}}
 </head>
 <body>
     <main>


### PR DESCRIPTION
Replace meta http-equiv refresh with JS redirect so crawlers read OG tags before redirect fires. Add og: prefix, Twitter card meta tags, and conditional og:image rendering to avoid empty image tags.